### PR TITLE
Safe Browsing API Abuse Check

### DIFF
--- a/TypoMagic/safebrowsing.py
+++ b/TypoMagic/safebrowsing.py
@@ -1,3 +1,4 @@
+import datetime as DT
 import http.client
 from urllib import parse
 
@@ -19,6 +20,35 @@ def safebrowsingquery (query_hostname, key):
     if key == "":
         # Return the same as a positive response string if the Safe Browsing API key is missing.
         return ("")
+
+    try:
+        f = open('api_count.txt', 'r+')
+        line = f.readline()
+        date = line[:19]
+        length =  len(line)
+        value = int(line[20:length])
+        now = DT.datetime.now()
+        then = DT.datetime.strptime(date, "%Y-%m-%d %H:%M:%S")
+        delta = now - then
+        if (value < 10000) and ((now - then).seconds < 86400):
+            value += 1
+            f = open('api_count.txt', 'w')
+            f.write(date + "=" + str(value))		
+        elif ((now - then).seconds > 86400): # If the delta is more than 24 hours reset the counter
+            today = DT.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            f.write(str(today) + "=1")		
+        else: # API limit reached
+            return("")
+        f.close()
+    except:
+        """Safe browsing count does not exist or an error of some sort
+        In this case then write the current time plus the API count e.g.
+        2014-01-05 14:47:25=0
+        """
+        f = open('api_count.txt', 'w')
+        today = DT.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        f.write(str(today) + "=1")
+        f.close()
 		
     # Build the query URL to send to Google Safe Browsing
     # TODO: Put some intelligence around this function because you rely on the user to enter a URL without the protocol, which BTW you don't actually need to send to GSB
@@ -53,26 +83,40 @@ def safebrowsingqueryv2 (query_hostname, key):
     if key == "":
         # Return the same as a positive response string if the Safe Browsing API key is missing.
         return ("")
-
-    # Make sure the Google Safe Browsing API is not abused
+		
+    """This code block will deal with Google Safe Browsing API abuse.
+	It will check the current datetime and compare this against the api_count.txt value.
+	If the count is more than 10K and the datetime is with a 24 time frame then the function will just return with no results.
+    """
     try:
         f = open('api_count.txt', 'r+')
         line = f.readline()
-        value = int(line)
-        if value < 10000:
+        date = line[:19]
+        length =  len(line)
+        value = int(line[20:length])
+        now = DT.datetime.now()
+        then = DT.datetime.strptime(date, "%Y-%m-%d %H:%M:%S")
+        delta = now - then
+        if (value < 10000) and ((now - then).seconds < 86400):
             value += 1
             f = open('api_count.txt', 'w')
-            f.write(str(value))		
-        else:
-            # API limit reached, don't make any more calls
-            return ("")
+            f.write(date + "=" + str(value))		
+        elif ((now - then).seconds > 86400): # If the delta is more than 24 hours reset the counter
+            today = DT.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            f.write(str(today) + "=1")		
+        else: # API limit reached
+            return("")
         f.close()
     except:
-        # Safe browsing count does not exist, set the value to one and continue
+        """Safe browsing count does not exist or an error of some sort
+        In this case then write the current time plus the API count e.g.
+        2014-01-05 14:47:25=0
+        """
         f = open('api_count.txt', 'w')
-        f.write("1")
+        today = DT.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        f.write(str(today) + "=1")
         f.close()
-		
+	
     query_url = parse.quote("http://" + query_hostname, safe='')
 
     connection = http.client.HTTPSConnection("sb-ssl.google.com")


### PR DESCRIPTION
Added some functionality that will ensure that no more than 10K API calls will be made in a 24 hour period. If the limit is reached within the 24 hour period then it will just return no data (as happens when no API key is provided).

Functionality tested and works.
