### PR TITLE
fixed arrTypoResp typo

### DIFF
--- a/typoclient/typoclient.py
+++ b/typoclient/typoclient.py
@@ -287,7 +287,7 @@ if __name__ == '__main__':
             arrTypoResp = requests.post(strURLTypos, data=strTypoRequest, headers=strHTTPHdrs, verify=args.certchecks)
 
             if arrTypoResp.text.startswith("[!]"):
-                print(arrTypoRest.text)
+                print(arrTypoResp.text)
                 sys.exit(0)
 
             strTypoJSON = arrTypoResp.json()


### PR DESCRIPTION
Fixed typo arrTypoRest to arrTypoResp. 

This is triggered when a domain is used without a TLD i.e. 'python typoclient.py -d nccgroup'

Instead of this error: '[i] Other error - <class 'NameError'> - name 'arrTypoRest' is not defined'

You get a more meaningful one: '[!] Invalid domain nccgroup'
